### PR TITLE
Allow other plugins to suppress FrozenJoin actions and fix bug with FrozenJoinEvent and FrozenQuitEvent

### DIFF
--- a/src/main/kotlin/com/github/frcsty/listener/base/PlayerJoinListener.kt
+++ b/src/main/kotlin/com/github/frcsty/listener/base/PlayerJoinListener.kt
@@ -17,6 +17,10 @@ class PlayerJoinListener(private val loader: Loader) : Listener {
 
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {
+
+        // If the join message is already empty, assume that this event isn't supposed to run
+        if (event.joinMessage.equals("")) return
+
         event.joinMessage = ""
 
         val actionHandler = loader.actionHandler

--- a/src/main/kotlin/com/github/frcsty/listener/base/PlayerQuitListener.kt
+++ b/src/main/kotlin/com/github/frcsty/listener/base/PlayerQuitListener.kt
@@ -16,6 +16,10 @@ class PlayerQuitListener(private val loader:Loader) : Listener {
 
     @EventHandler
     fun onPlayerLeave(event: PlayerQuitEvent) {
+
+        // If the quit message is already empty, assume that this event isn't supposed to run
+        if (event.quitMessage.equals("")) return
+
         event.quitMessage = ""
 
         val manager = loader.formatManager

--- a/src/main/kotlin/com/github/frcsty/listener/event/FrozenJoinEvent.kt
+++ b/src/main/kotlin/com/github/frcsty/listener/event/FrozenJoinEvent.kt
@@ -6,14 +6,17 @@ import org.bukkit.event.HandlerList
 
 class FrozenJoinEvent(private val player: Player, private val actions: List<String>) : Event() {
 
-    private val handlers = HandlerList()
 
-    fun getHandlerList(): HandlerList? {
-        return handlers
+    companion object {
+        @JvmStatic private val handlers = HandlerList()
+        @JvmStatic
+        fun getHandlerList(): HandlerList {
+            return handlers
+        }
     }
 
     override fun getHandlers(): HandlerList {
-        return handlers
+        return getHandlerList()
     }
 
     fun getPlayer(): Player {

--- a/src/main/kotlin/com/github/frcsty/listener/event/FrozenQuitEvent.kt
+++ b/src/main/kotlin/com/github/frcsty/listener/event/FrozenQuitEvent.kt
@@ -6,14 +6,17 @@ import org.bukkit.event.HandlerList
 
 class FrozenQuitEvent(private val player: Player, private val actions: List<String>) : Event() {
 
-    private val handlers = HandlerList()
+    companion object {
+        @JvmStatic private val handlers = HandlerList()
 
-    fun getHandlerList(): HandlerList? {
-        return handlers
+        @JvmStatic
+        fun getHandlerList(): HandlerList {
+            return handlers
+        }
     }
 
     override fun getHandlers(): HandlerList {
-        return handlers
+        return getHandlerList()
     }
 
     fun getPlayer(): Player {


### PR DESCRIPTION
Bukkit requires Events to have a static `getHandlers` method. Previously the method wasn't static so Bukkit would throw an error when the event was being registered.

For suppressing FrozenJoin actions on join/quit, the way I did it is super jank. If someone has a better way to this it would be a lot better.